### PR TITLE
Fix left shift on signed int channel setting sign bit and causing UB

### DIFF
--- a/createdfd.c
+++ b/createdfd.c
@@ -117,6 +117,12 @@ static void writeSample(uint32_t *DFD, int sampleNo, int channel,
     if (channel == 3) channel = KHR_DF_CHANNEL_RGBSDA_ALPHA;
     channel = setChannelFlags(channel, suffix);
 
+    // `channel` is cast into an uint32_t to avoid the following issue:
+    //  When `channel` is 192, the following UB occurs: 11000000 << 24
+    //  Setting sign bit of an integer via a left shift operation is UB.
+    //
+    //  TODO: This is the least intrusive solution for the moment. Ideally,
+    //        writeSample should take uint32_t params.
     sample[KHR_DF_SAMPLEWORD_BITOFFSET] =
         (offset << KHR_DF_SAMPLESHIFT_BITOFFSET) |
         ((bits - 1) << KHR_DF_SAMPLESHIFT_BITLENGTH) |

--- a/createdfd.c
+++ b/createdfd.c
@@ -120,7 +120,7 @@ static void writeSample(uint32_t *DFD, int sampleNo, int channel,
     sample[KHR_DF_SAMPLEWORD_BITOFFSET] =
         (offset << KHR_DF_SAMPLESHIFT_BITOFFSET) |
         ((bits - 1) << KHR_DF_SAMPLESHIFT_BITLENGTH) |
-        (channel << KHR_DF_SAMPLESHIFT_CHANNELID);
+        ((uint32_t)channel << KHR_DF_SAMPLESHIFT_CHANNELID);
 
     sample[KHR_DF_SAMPLEWORD_SAMPLEPOSITION_ALL] = 0;
 


### PR DESCRIPTION
I don't whether this was causing any issues, but:

* When the signed integer (type: int) is 192, the following undefined behavior occurs: 11000000 << 24 => is undefined behavior because setting sign bit of an integer via a left shift operation is UB. Simply cast channel to uint32_t before shifting.

* To replicate: build with -fsanitize="undefined" and navigate to KTX-Software/tests/cts/clitests then:
ktx transcode --testrun input/ktx2/valid_R16G16_SFLOAT_CUBE_ARRAY.ktx2 / output/transcode/transcode_error_not_transcodable/output_R16G16_SFLOAT_CUBE_ARRAY.ktx2

You will get the following:

KTX-Software/external/dfdutils/createdfd.c:123:18: runtime error: left shift of 192 by 24 places cannot be represented in type 'int'